### PR TITLE
Updated drivers.py and monitors.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# cocotb modules for AXI4-Stream
+
+This cocotb extension contains a master driver, a slave driver and a monitor for
+the AMBA AXI4-Stream protocol.
+
+## Installation
+
+Clone this repository, then run:
+
+```
+python3 -m pip install -e cocotbext-axi4stream
+```
+

--- a/cocotbext/axi4stream/__init__.py
+++ b/cocotbext/axi4stream/__init__.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 
 from . import drivers
 from . import monitors

--- a/cocotbext/axi4stream/monitors.py
+++ b/cocotbext/axi4stream/monitors.py
@@ -51,12 +51,12 @@ class Axi4Stream(BusMonitor):
         Args:
             *args: passed directly to the BusMonitor parent constructor.
             packets (bool, optional): wait for a high TLAST to call _recv.
-                Defaults to False (call _recv on every transaction).
+                Defaults to False (call _recv on every transfer).
             aux_signals (bool, optional): when true, return a dict for each
-                AXI4-Stream transaction where the key is the name of the signal
+                AXI4-Stream transfer where the key is the name of the signal
                 and the value is the value of it.
-                When false, return an int for each transaction representing
-                the value of the TDATA signal
+                When false, return an int for each transfer representing the
+                value of the TDATA signal
             data_type (str, optional): select the data type passed to _recv,
                 either "buff" (for binary buffers of bytes) or "integer".
             **kwargs: passed directly to the BusMonitor parent constructor.
@@ -78,7 +78,8 @@ class Axi4Stream(BusMonitor):
 
         self.bus_optional_signals = \
             tuple(signal for signal in Axi4Stream._optional_data_signals
-                  if hasattr(self.bus, signal))
+                  if hasattr(self.bus, signal) and
+                  (signal != "TLAST" or not packets))
 
     @cocotb.coroutine
     async def _monitor_recv(self):

--- a/cocotbext/axi4stream/monitors.py
+++ b/cocotbext/axi4stream/monitors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 Nicola Corna <nicola.corna@polimi.it>
 # All rights reserved.
 #
@@ -27,7 +27,7 @@
 
 """Monitors for Advanced Microcontroller Bus Architecture."""
 
-from cocotb.decorators import coroutine
+import cocotb
 from cocotb.monitors import BusMonitor
 from cocotb.triggers import RisingEdge
 
@@ -80,8 +80,8 @@ class Axi4Stream(BusMonitor):
             tuple(signal for signal in Axi4Stream._optional_data_signals
                   if hasattr(self.bus, signal))
 
-    @coroutine
-    def _monitor_recv(self):
+    @cocotb.coroutine
+    async def _monitor_recv(self):
         """Watch the pins and reconstruct transfers and packets."""
 
         def valid_transfer():
@@ -98,7 +98,7 @@ class Axi4Stream(BusMonitor):
 
         packet = []
         while True:
-            yield clk_redge
+            await clk_redge
 
             if valid_transfer():
                 if self.aux_signals:

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,17 @@
-#! /usr/bin/python
-from setuptools import setup
+#!/usr/bin/env python3
+
+from setuptools import setup, find_namespace_packages
 
 setup(
     name="cocotbext.axi4stream",
-    use_scm_version={
-        "relative_to": __file__,
-        "write_to": "cocotbext/axi4stream/version.py",
-    },
+    version="1.0",
     author="Nicola Corna",
     author_email="nicola.corna@polimi.it",
     description="Cocotb AXI4-Stream module",
     url="https://github.com/corna/cocotbext.axi4stream.git",
-    packages=["cocotbext.axi4stream"],
+    packages=find_namespace_packages(include=['cocotbext.*']),
     install_requires=['cocotb'],
-    setup_requires=[
-        'setuptools_scm',
-    ],
+    python_requires='>=3.5',
     classifiers=[
         "Programming Language :: Python",
         "License :: OSI Approved :: MIT License",

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,15 @@
+PWD				:= $(shell pwd)
+
+SIM				?= ghdl
+SIM_ARGS		?= --wave=$(PWD)/build/waveform.ghw
+
+TOPLEVEL_LANG	= vhdl
+
+SIM_BUILD		= $(PWD)/build
+MODULE			= axi4stream_inverter
+TOPLEVEL		= axi4stream_inverter
+
+VHDL_SOURCES	= $(PWD)/axi4stream_inverter.vhd
+
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/axi4stream_inverter.py
+++ b/tests/axi4stream_inverter.py
@@ -1,0 +1,136 @@
+#!//usr//bin//env python3
+
+from random import randint
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.regression import TestFactory
+from cocotb.scoreboard import Scoreboard
+from cocotb.triggers import RisingEdge, Timer
+from cocotbext.axi4stream.drivers import Axi4StreamMaster, Axi4StreamSlave
+from cocotbext.axi4stream.monitors import Axi4Stream
+
+CLK_PERIOD = 10
+
+
+@cocotb.coroutine
+async def setup_dut(dut):
+    cocotb.fork(Clock(dut.aclk, CLK_PERIOD, "ns").start())
+    dut.aresetn <= 0
+    await Timer(CLK_PERIOD * 2, "ns")
+    dut.aresetn <= 1
+    await Timer(CLK_PERIOD * 2, "ns")
+
+
+@cocotb.test()
+async def test_tdata(dut, packets_num=5, packet_size=(10, 100), delay=-1, consecutive_transfers=0):
+    """Test TDATA"""
+
+    tdata_width = dut.C_S_AXIS_TDATA_WIDTH.value.integer
+
+    axis_m = Axi4StreamMaster(dut, "s_axis", dut.aclk)
+    axis_s = Axi4StreamSlave(dut, "m_axis", dut.aclk, delay, consecutive_transfers)
+    axis_monitor = Axi4Stream(dut, "m_axis", dut.aclk, data_type="integer", packets=True)
+
+    await setup_dut(dut)
+
+    input = []
+    output = []
+
+    # Build the input and output packets
+    for i in range(packets_num):
+        input.append([randint(0, 2**tdata_width - 1) for i in range(randint(*packet_size))])
+        output.append([word ^ 2**tdata_width - 1 for word in input[-1]])
+
+    scoreboard = Scoreboard(dut)
+    scoreboard.add_interface(axis_monitor, output)
+
+    # Write the input packets
+    for packet in input:
+        await axis_m.write(packet)
+
+    # Wait until output is empty (so, all the packets have been received)
+    while output:
+        await RisingEdge(dut.aclk)
+
+    await RisingEdge(dut.aclk)
+
+
+@cocotb.test()
+async def test_aux(dut, packets_num=5, packet_size=(10, 100), delay=-1, consecutive_transfers=0):
+    """Test all the auxiliary AXI4-Stream signals"""
+
+    tdata_width = dut.C_S_AXIS_TDATA_WIDTH.value.integer
+    tdest_width = dut.C_S_AXIS_TDEST_WIDTH.value.integer
+    tid_width = dut.C_S_AXIS_TID_WIDTH.value.integer
+    tuser_width = dut.C_S_AXIS_TUSER_WIDTH.value.integer
+
+    axis_m = Axi4StreamMaster(dut, "s_axis", dut.aclk)
+    axis_s = Axi4StreamSlave(dut, "m_axis", dut.aclk, delay, consecutive_transfers)
+    axis_monitor = Axi4Stream(dut, "m_axis", dut.aclk, data_type="integer", packets=True, aux_signals=True)
+
+    await setup_dut(dut)
+
+    input = []
+    output = []
+
+    # Build the input and output packets
+    for i in range(packets_num):
+        first_word = {
+            "TDATA": randint(0, 2**tdata_width - 1),
+            "TSTRB": randint(0, 2**(tdata_width // 8) - 1),
+            "TKEEP": 2**(tdata_width // 8) - 1,
+            "TDEST": randint(0, 2**tdest_width - 1),
+            "TID": randint(0, 2**tid_width - 1),
+            "TUSER": randint(0, 2**tuser_width - 1),
+        }
+        second_word = {
+            "TDATA": randint(0, 2**tdata_width - 1),
+            "TSTRB": 2**(tdata_width // 8) - 1
+        }
+        input.append(
+            [first_word, second_word] +
+            [randint(0, 2**tdata_width - 1) for i in range(randint(*packet_size))])
+
+        output.append([])
+        for input_word in input[-1]:
+            output[-1].append({})
+            for signal in ("TDATA", "TSTRB", "TKEEP", "TDEST", "TID", "TUSER"):
+                if signal == "TDATA" and isinstance(input_word, int):
+                    output[-1][-1]["TDATA"] = input_word
+                else:
+                    try:
+                        # If input_word has that signal, copy it, ...
+                        output[-1][-1][signal] = input_word[signal]
+                    except (KeyError, TypeError):
+                        # ...if not, use the last value
+                        output[-1][-1][signal] = output[-1][-2][signal]
+
+        for output_word in output[-1]:
+            # Flip TDATA and TUSER
+            output_word["TDATA"] ^= 2**tdata_width - 1
+            output_word["TUSER"] ^= 2**tuser_width - 1
+
+    scoreboard = Scoreboard(dut)
+    scoreboard.add_interface(axis_monitor, output)
+
+    # Write the input packets
+    for packet in input:
+        await axis_m.write(packet)
+
+    # Wait until output_tdata is empty (so, all the packets have been received)
+    while output:
+        await RisingEdge(dut.aclk)
+
+
+tdata_test_factory = TestFactory(test_tdata)
+tdata_test_factory.add_option('delay', (0, 1, lambda dut: randint(2, 10)))
+tdata_test_factory.add_option('consecutive_transfers',
+                              (0, 1, 5, lambda dut: randint(1, 5)))
+tdata_test_factory.generate_tests()
+
+aux_test_factory = TestFactory(test_aux)
+aux_test_factory.add_option('delay', (0, 1, lambda dut: randint(2, 10)))
+aux_test_factory.add_option('consecutive_transfers',
+                            (0, 1, 5, lambda dut: randint(1, 5)))
+aux_test_factory.generate_tests()

--- a/tests/axi4stream_inverter.vhd
+++ b/tests/axi4stream_inverter.vhd
@@ -1,0 +1,89 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+
+entity axi4stream_inverter is
+	generic (
+		C_S_AXIS_TDATA_WIDTH	: natural := 32;
+		C_S_AXIS_TUSER_WIDTH	: natural := 16;
+		C_S_AXIS_TDEST_WIDTH	: natural := 8;
+		C_S_AXIS_TID_WIDTH		: natural := 8
+	);
+	port (
+		aclk			: in std_logic;
+		aresetn			: in std_logic;
+
+		s_axis_tvalid	: in std_logic;
+		s_axis_tdata	: in std_logic_vector(C_S_AXIS_TDATA_WIDTH-1 downto 0);
+		s_axis_tstrb	: in std_logic_vector(C_S_AXIS_TDATA_WIDTH/8-1 downto 0);
+		s_axis_tkeep	: in std_logic_vector(C_S_AXIS_TDATA_WIDTH/8-1 downto 0);
+		s_axis_tdest	: in std_logic_vector(C_S_AXIS_TDEST_WIDTH-1 downto 0);
+		s_axis_tid		: in std_logic_vector(C_S_AXIS_TID_WIDTH-1 downto 0);
+		s_axis_tuser	: in std_logic_vector(C_S_AXIS_TUSER_WIDTH-1 downto 0);
+		s_axis_tlast	: in std_logic;
+		s_axis_tready	: out std_logic;
+
+		m_axis_tvalid	: out std_logic;
+		m_axis_tdata	: out std_logic_vector(C_S_AXIS_TDATA_WIDTH-1 downto 0);
+		m_axis_tstrb	: out std_logic_vector(C_S_AXIS_TDATA_WIDTH/8-1 downto 0);
+		m_axis_tkeep	: out std_logic_vector(C_S_AXIS_TDATA_WIDTH/8-1 downto 0);
+		m_axis_tdest	: out std_logic_vector(C_S_AXIS_TDEST_WIDTH-1 downto 0);
+		m_axis_tid		: out std_logic_vector(C_S_AXIS_TID_WIDTH-1 downto 0);
+		m_axis_tuser	: out std_logic_vector(C_S_AXIS_TUSER_WIDTH-1 downto 0);
+		m_axis_tlast	: out std_logic;
+		m_axis_tready	: in std_logic
+	);
+end axi4stream_inverter;
+
+architecture Behavioral of axi4stream_inverter is
+
+	signal m_axis_tvalid_int	: std_logic;
+	signal s_axis_tready_int	: std_logic;
+
+begin
+
+	-- We can accept new data from the slave interface if the reset is not
+	-- active and:
+	--  * either our memory element is empty (not m_axis_tvalid_int), or
+	--  * we can write on the master interface
+	s_axis_tready_int	<= aresetn and (m_axis_tready or not m_axis_tvalid_int);
+
+	m_axis_tvalid		<= m_axis_tvalid_int;
+	s_axis_tready		<= s_axis_tready_int;
+
+	process(aclk)
+	begin
+		if rising_edge(aclk) then
+
+			if aresetn = '0' then
+
+				m_axis_tvalid_int	<= '0';
+
+			else
+
+				-- If slave valid is 1, raise master valid.
+				-- If it is low, keep the previous value until a high ready,
+				-- then reset to 0.
+				if s_axis_tvalid = '1' then
+					m_axis_tvalid_int	<= '1';
+				elsif m_axis_tready = '1' then
+					m_axis_tvalid_int	<= '0';
+				end if;
+
+				-- If the transaction in this clock cycle has been performed (on
+				-- the slave port), then update the data on the master port.
+				if s_axis_tvalid = '1' and s_axis_tready_int = '1' then
+					m_axis_tdata	<= not s_axis_tdata;
+					m_axis_tstrb	<= s_axis_tstrb;
+					m_axis_tkeep	<= s_axis_tkeep;
+					m_axis_tdest	<= s_axis_tdest;
+					m_axis_tid		<= s_axis_tid;
+					m_axis_tuser	<= not s_axis_tuser;
+					m_axis_tlast	<= s_axis_tlast;
+				end if;
+
+			end if;
+
+		end if;
+	end process;
+
+end Behavioral;


### PR DESCRIPTION
This commit updates drivers.py and monitor.py adding new functionalities:
	* drivers.py now supports all the possible "_optional_signals" of the bus for the "write" coroutine. This is achieved by using int or dict (or iterable of ints/dicts) data.
	* monitors.py now is expected to be fed w/ int or dict (or iterable of ints/dicts) data instead of named tuple data.