### PR TITLE
Deprecation Fix

### DIFF
--- a/cocotbext/axi4stream/drivers.py
+++ b/cocotbext/axi4stream/drivers.py
@@ -103,7 +103,7 @@ class Axi4StreamMaster(BusDriver):
         if sync:
             await RisingEdge(self.clock)
 
-        self.bus.TVALID <= 1
+        self.bus.TVALID.value = 1
 
         for index, word in enumerate(data):
             # If word is not a dict, make it (using word as "TDATA")
@@ -124,22 +124,22 @@ class Axi4StreamMaster(BusDriver):
                                                 "AXI4-Stream signal")
 
                 try:
-                    getattr(self.bus, signal) <= value
+                    getattr(self.bus, signal).value = value
                 except AttributeError:
                     raise TestFailure(err_msg + "not present on the bus")
 
             if hasattr(self.bus, "TLAST") and tlast_on_last and \
                index == len(data) - 1:
-                self.bus.TLAST <= 1
+                self.bus.TLAST.value = 1
 
             await RisingEdge(self.clock)
             while hasattr(self.bus, "TREADY") and not self.bus.TREADY.value:
                 await RisingEdge(self.clock)
 
         if hasattr(self.bus, "TLAST") and tlast_on_last:
-            self.bus.TLAST <= 0
+            self.bus.TLAST.value = 0
 
-        self.bus.TVALID <= 0
+        self.bus.TVALID.value = 0
 
     @property
     def n_bits(self):
@@ -226,7 +226,7 @@ class Axi4StreamSlave(BusDriver):
                                   FallingEdge(self.bus.TVALID))
 
             if trigger is tready_high_delay:
-                self.bus.TREADY <= 1
+                self.bus.TREADY.value = 1
 
                 if callable(self.consecutive_transfers):
                     num_cycles = self.consecutive_transfers(self.bus)
@@ -239,5 +239,5 @@ class Axi4StreamSlave(BusDriver):
                 else:
                     await FallingEdge(self.bus.TVALID)
 
-                self.bus.TREADY <= 0
+                self.bus.TREADY.value = 0
                 await RisingEdge(self.clock)

--- a/cocotbext/axi4stream/drivers.py
+++ b/cocotbext/axi4stream/drivers.py
@@ -202,7 +202,7 @@ class Axi4StreamSlave(BusDriver):
                 self.tready_delay = tready_delay
                 self.consecutive_transfers = consecutive_transfers
 
-                cocotb.fork(self._receive_data())
+                cocotb.start_soon(self._receive_data())
 
     @cocotb.coroutine
     async def _receive_data(self):

--- a/tests/axi4stream_inverter.py
+++ b/tests/axi4stream_inverter.py
@@ -16,9 +16,9 @@ CLK_PERIOD = 10
 @cocotb.coroutine
 async def setup_dut(dut):
     cocotb.fork(Clock(dut.aclk, CLK_PERIOD, "ns").start())
-    dut.aresetn <= 0
+    dut.aresetn.value = 0
     await Timer(CLK_PERIOD * 2, "ns")
-    dut.aresetn <= 1
+    dut.aresetn.value = 1
     await Timer(CLK_PERIOD * 2, "ns")
 
 

--- a/tests/axi4stream_inverter.py
+++ b/tests/axi4stream_inverter.py
@@ -15,7 +15,7 @@ CLK_PERIOD = 10
 
 @cocotb.coroutine
 async def setup_dut(dut):
-    cocotb.fork(Clock(dut.aclk, CLK_PERIOD, "ns").start())
+    cocotb.start_soon(Clock(dut.aclk, CLK_PERIOD, "ns").start())
     dut.aresetn.value = 0
     await Timer(CLK_PERIOD * 2, "ns")
     dut.aresetn.value = 1


### PR DESCRIPTION
This PR updates deprecated calls to `fork()` method and `<=` assignments. 🙂